### PR TITLE
control(update): 4.2.1.4 rsyslog config

### DIFF
--- a/controls/4_2_configure_logging.rb
+++ b/controls/4_2_configure_logging.rb
@@ -80,7 +80,7 @@ control 'cis-dil-benchmark-4.2.1.4' do
   '
   impact 1.0
 
-  tag cis: 'distribution-independent-linux:4.2.1.3'
+  tag cis: 'distribution-independent-linux:4.2.1.4'
   tag level: 1
 
   # ryslog default file permissions are '0644'
@@ -92,7 +92,7 @@ control 'cis-dil-benchmark-4.2.1.4' do
     its('content') { should match(/^\$FileCreateMode\s+0[0-6][0-4]0/) }
   end
 
-  # individual service config shouldn't overwrite /etc/rsyslog.conf
+  ## individual service config shouldn't overwrite /etc/rsyslog.conf - Legacy
   rsyslogd_files = command('grep -l ^\$FileCreateMode /etc/rsyslog.d/*.conf').stdout
 
   rsyslogd_files.each_line do |filename|
@@ -101,10 +101,19 @@ control 'cis-dil-benchmark-4.2.1.4' do
     end
   end
 
-  # TODO: this control (as defined by the benchmark) only checks the 'legacy' rsyslog syntax
+  
+  # Check the new RainerScript format in addtion to the 'legacy' rsyslog syntax
   # which is documented as 'obsolete'
   # ref: https://www.rsyslog.com/doc/v8-stable/configuration/modules/omfile.html#filecreatemode
+  new_rsyslog_conf = command('grep -orE \'FileCreateMode="[0-7]{4}"\' /etc/rsyslog.*').stdout
+  new_rsyslog_conf.each_line do | result |
+    filename = result.split(':')[0]
+    describe file(filename) do
+      its('content') { should match(/FileCreateMode="0[0-6][0-4]0"/) }
+    end
+  end
 end
+
 
 control 'cis-dil-benchmark-4.2.1.5' do
   title 'Ensure rsyslog is configured to send logs to a remote log host'


### PR DESCRIPTION
Check for newer rsyslog config that would ignore the legacy format if
used